### PR TITLE
Fix parsing encoded invoice

### DIFF
--- a/lightspark/Cargo.toml
+++ b/lightspark/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lightspark"
 description = "Lightspark Rust SDK"
 authors = ["Lightspark Group, Inc. <info@lightspark.com>"]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 documentation = "https://docs.lightspark.com/lightspark-sdk/getting-started?language=Rust"
 homepage = "https://www.lightspark.com/"

--- a/lightspark/README.md
+++ b/lightspark/README.md
@@ -1,4 +1,4 @@
-# Lightspark Rust SDK - v0.8.1
+# Lightspark Rust SDK - v0.8.2
 
 The Lightspark Rust SDK provides a convenient way to interact with the Lightspark services from applications written in the Rust language.
 

--- a/lightspark/src/client.rs
+++ b/lightspark/src/client.rs
@@ -805,8 +805,10 @@ impl<K: OperationSigningKey> LightsparkClient<K> {
             .execute_graphql(mutation, Some(value))
             .await?;
 
-        let result = json["create_test_mode_invoice"]["encoded_payment_request"].clone();
-        Ok(result.to_string())
+        Ok(json["create_test_mode_invoice"]["encoded_payment_request"]
+            .as_str()
+            .ok_or_else(|| Error::GraphqlError("unable to parse the encoded invoice".into()))?
+            .to_owned())
     }
 
     pub async fn create_test_mode_payment(


### PR DESCRIPTION
Encoded invoice value should be without quotation marks to be able to pass to pay_invoice. In order for that it should be converted to Rust String type using `.as_str()`. See serde readme for more details.