### PR TITLE
Enable Signet network

### DIFF
--- a/lightspark-remote-signing/src/signer.rs
+++ b/lightspark-remote-signing/src/signer.rs
@@ -27,6 +27,7 @@ pub enum Network {
     Bitcoin,
     Testnet,
     Regtest,
+    Signet,
 }
 
 impl fmt::Display for Error {
@@ -119,6 +120,7 @@ impl LightsparkSigner {
             Network::Bitcoin => bitcoin::Network::Bitcoin,
             Network::Testnet => bitcoin::Network::Testnet,
             Network::Regtest => bitcoin::Network::Regtest,
+            Network::Signet => bitcoin::Network::Signet,
         };
         let master_private_key = ExtendedPrivKey::new_master(network, seed.as_bytes().as_slice())
             .map_err(|_| Error::KeyDerivationError)?;

--- a/lightspark-remote-signing/src/signing_requests.rs
+++ b/lightspark-remote-signing/src/signing_requests.rs
@@ -323,6 +323,7 @@ fn bitcoin_network_from_webhook_event(event: &WebhookEvent) -> Result<BitcoinNet
         "MAINNET" => Ok(BitcoinNetwork::Mainnet),
         "TESTNET" => Ok(BitcoinNetwork::Testnet),
         "REGTEST" => Ok(BitcoinNetwork::Regtest),
+        "SIGNET" => Ok(BitcoinNetwork::Signet),
         _ => Err(Error::WebhookEventDataMissing),
     }
 }

--- a/lightspark/src/objects/permission.rs
+++ b/lightspark/src/objects/permission.rs
@@ -36,6 +36,15 @@ pub enum Permission {
     #[serde(rename = "REGTEST_MANAGE")]
     RegtestManage,
 
+    #[serde(rename = "SIGNET_VIEW")]
+    SignetView,
+
+    #[serde(rename = "SIGNET_TRANSACT")]
+    SignetTransact,
+
+    #[serde(rename = "SIGNET_MANAGE")]
+    SignetManage,
+
     #[serde(rename = "USER_VIEW")]
     UserView,
 
@@ -68,6 +77,9 @@ impl fmt::Display for Permission {
             Self::RegtestView => write!(f, "REGTEST_VIEW"),
             Self::RegtestTransact => write!(f, "REGTEST_TRANSACT"),
             Self::RegtestManage => write!(f, "REGTEST_MANAGE"),
+            Self::SignetView => write!(f, "SIGNET_VIEW"),
+            Self::SignetTransact => write!(f, "SIGNET_TRANSACT"),
+            Self::SignetManage => write!(f, "SIGNET_MANAGE"),
             Self::UserView => write!(f, "USER_VIEW"),
             Self::UserManage => write!(f, "USER_MANAGE"),
             Self::AccountView => write!(f, "ACCOUNT_VIEW"),


### PR DESCRIPTION
Enable Signet network in the code that is used in the remote signer for Sparknode. This will allow testing lightning payments to Spark using Signet.

Towards LPT-225