### PR TITLE
Enable Signet network

### DIFF
--- a/lightspark-remote-signing/CHANGELOG.md
+++ b/lightspark-remote-signing/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.5.0
+- Added Signet Bitcoin network support.
+
 ## v0.3.0
 - Handle REVEAL_COUNTERPARTY_PER_COMMITMENT_SECRET webhook.
 

--- a/lightspark-remote-signing/Cargo.toml
+++ b/lightspark-remote-signing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lightspark-remote-signing"
 description = "Lightspark Remote Signing SDK for Rust"
 authors = ["Lightspark Group, Inc. <info@lightspark.com>"]
-version = "0.3.0"
+version = "0.5.0"
 edition = "2021"
 documentation = "https://docs.lightspark.com/lightspark-sdk/getting-started?language=Rust"
 homepage = "https://www.lightspark.com/"

--- a/lightspark/CHANGELOG.md
+++ b/lightspark/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# v0.11.0
+- Added Signet Bitcoin network support.
+
 # v0.10.1
 - Fix: Removes default params on graphql mutation `PayUmaInvoice`
 

--- a/lightspark/Cargo.toml
+++ b/lightspark/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lightspark"
 description = "Lightspark Rust SDK"
 authors = ["Lightspark Group, Inc. <info@lightspark.com>"]
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 documentation = "https://docs.lightspark.com/lightspark-sdk/getting-started?language=Rust"
 homepage = "https://www.lightspark.com/"

--- a/lightspark/src/lib.rs
+++ b/lightspark/src/lib.rs
@@ -28,7 +28,7 @@
 //! See more examples in examples/example.rs
 //!
 /// The version of this library.
-pub const VERSION: &str = "0.10.1";
+pub const VERSION: &str = "0.11.0";
 
 #[cfg(feature = "client")]
 pub mod client;


### PR DESCRIPTION
Enable Signet network in the code that is used in the remote signer for Sparknode. This will allow testing lightning payments to Spark using Signet.

Towards LPT-225