### PR TITLE
Add example Dockerfile to build the remote signer

### DIFF
--- a/examples/lightspark-remote-signing-server/Dockerfile
+++ b/examples/lightspark-remote-signing-server/Dockerfile
@@ -1,0 +1,32 @@
+FROM --platform=$BUILDPLATFORM rust:1.84-slim-bookworm AS builder
+
+ARG TARGETOS TARGETARCH
+RUN echo "$TARGETARCH" | sed 's,arm,aarch,;s,amd,x86_,' > /tmp/arch
+
+RUN apt-get update && apt-get install -y "gcc-$(tr _ - < /tmp/arch)-linux-gnu" "g++-$(tr _ - < /tmp/arch)-linux-gnu" make && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN rustup target add "$(cat /tmp/arch)-unknown-${TARGETOS}-gnu"
+
+WORKDIR /usr/src/remote-signer
+
+COPY Cargo.toml Cargo.lock .
+COPY examples/ examples
+COPY lightspark/ lightspark
+COPY lightspark-remote-signing/ lightspark-remote-signing/
+
+RUN cargo build -r --bin lightspark-remote-signing-server 
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y ca-certificates bash htop && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN addgroup --system --gid 1000 sparknode
+RUN adduser --system --uid 1000 --home /home/sparknode --ingroup sparknode sparknode
+
+ENTRYPOINT ["remote-signing-server"]
+EXPOSE 8000
+
+COPY --from=builder /usr/src/remote-signer/target/release/lightspark-remote-signing-server /usr/local/bin/remote-signing-server
+
+# Install security updates
+RUN apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt/lists
+
+RUN remote-signing-server

--- a/examples/lightspark-remote-signing-server/src/config.rs
+++ b/examples/lightspark-remote-signing-server/src/config.rs
@@ -11,11 +11,11 @@ pub struct Config {
 
 impl Config {
     pub fn new_from_env() -> Self {
-        let api_endpoint = std::env::var("RK_API_ENDPOINT").ok();
-        let api_client_id = std::env::var("RK_API_CLIENT_ID").ok();
-        let api_client_secret = std::env::var("RK_API_CLIENT_SECRET").ok();
-        let webhook_secret = std::env::var("RK_WEBHOOK_SECRET").ok();
-        let master_seed_hex = std::env::var("RK_MASTER_SEED_HEX").ok();
+        let api_endpoint = std::env::var("API_ENDPOINT").ok();
+        let api_client_id = std::env::var("API_CLIENT_ID").ok();
+        let api_client_secret = std::env::var("API_CLIENT_SECRET").ok();
+        let webhook_secret = std::env::var("WEBHOOK_SECRET").ok();
+        let master_seed_hex = std::env::var("MASTER_SEED_HEX").ok();
         let api_port = std::env::var("PORT").ok();
         let respond_directly = std::env::var("RESPOND_DIRECTLY").is_ok();
 


### PR DESCRIPTION
Adding a Dockerfile to the example remote signing server so the example could be deployed to a cloud infra. Converge ENV names used in the remote signer to the Lightspark standard.

Towards LPT-224